### PR TITLE
Update bm25 reproduction readme

### DIFF
--- a/examples/bm25_en_caption/README.md
+++ b/examples/bm25_en_caption/README.md
@@ -18,7 +18,10 @@ T2I_FILE = "<filepath>"
 I2T_FILE = "<filepath>"
 
 qrel_ds = load_dataset('TREC-AToMiC/AToMiC-Qrels-v0.2', split=SPLIT)
-qrel_ds[SPLIT].to_csv(T2I_FILE, header=None, sep=' ', index=False) # T2I qrel
-qrel_ds[SPLIT].to_csv(I2T_FILE, colmns=['image_id', 'Q0', 'text_id', 'rel'), header=None, sep=' ', index=False) # I2T qrel
+qrel_ds.to_csv(T2I_FILE, header=None, sep=' ', index=False) # T2I qrel
+qrel_ds.to_csv(I2T_FILE, colmns=['image_id', 'Q0', 'text_id', 'rel'], header=None, sep=' ', index=False) # I2T qrel
 ```
 3. run `index_anserini.sh` and `search_anserini.sh`
+
+## Reproduction Log
++ Results reproduced by [@dlrudwo1269](https://github.com/dlrudwo1269) on <2023-04-09> (commit [`45a5540`](https://github.com/dlrudwo1269/AToMiC/commit/45a5540c473c48e4e7c68b0258b5ad23cf2e43d0))


### PR DESCRIPTION
1. Fix some typos in the script in step 2
2. Add reproduction log

Reproduced on Compute Canada computing node. Python 3.8.16 and Java 11.0.13.